### PR TITLE
Migrate scripts to new data source

### DIFF
--- a/docs/details/MFAImpersonationDefense.mdx
+++ b/docs/details/MFAImpersonationDefense.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 6
-id: MFAImpersonationDefense
+sidebar_position: 5
+id: 6
 title: Use MFA against impersonation
 slug: /details/MFAImpersonationDefense
 ---
@@ -8,20 +8,21 @@ slug: /details/MFAImpersonationDefense
 # Use MFA against impersonation
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Use Multi Factor Authentication (MFA) Methods that Defend Against Impersonation when Available 
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P1
 - Mitre: [CWE-290](https://cwe.mitre.org/data/definitions/290.html)
 - Sources: [OpenSSF Best Practices Badge Gold Level [secure_2FA]](https://www.bestpractices.dev/en/criteria/2#2.secure_2FA)
 - How To: [Github Docs](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/PRsBeforeMerge.mdx
+++ b/docs/details/PRsBeforeMerge.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 62
-id: PRsBeforeMerge
+sidebar_position: 61
+id: 62
 title: Require Pull Requests Before Merging
 slug: /details/PRsBeforeMerge
 ---
@@ -8,20 +8,21 @@ slug: /details/PRsBeforeMerge
 # Require Pull Requests Before Merging
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Require Pull Requests before Merging
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R4
 - Mitre: [CWE-778](https://cwe.mitre.org/data/definitions/778.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/SSHKeysRequired.mdx
+++ b/docs/details/SSHKeysRequired.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 11
-id: SSHKeysRequired
+sidebar_position: 10
+id: 11
 title: Use SSH Keys with Passphrases for Repository Access
 slug: /details/SSHKeysRequired
 ---
@@ -8,20 +8,21 @@ slug: /details/SSHKeysRequired
 # Use SSH Keys with Passphrases for Repository Access
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Use SSH keys for developer access to source code repositories and use a passphrase
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P3
 - Mitre: [CWE-309](https://cwe.mitre.org/data/definitions/309.html)
 - Sources: [CNCF SSCP v1.0 #192](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#use-ssh-keys-to-provide-developers-access-to-source-code-repositories)
 - How To: [Github Docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/activeAdminsSixMonths.mdx
+++ b/docs/details/activeAdminsSixMonths.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 60
-id: activeAdminsSixMonths
+sidebar_position: 59
+id: 60
 title: Require Active Admins in GitHub Org (Activity in 6 Months)
 slug: /details/activeAdminsSixMonths
 ---
@@ -8,20 +8,20 @@ slug: /details/activeAdminsSixMonths
 # Require Active Admins in GitHub Org (Activity in 6 Months)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 Github Organization Admins Should Have Activity In The Last 6 Months
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R3
 - Mitre: [M1026](https://attack.mitre.org/mitigations/M1026/)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/member/stale_admin_found.html)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/activeWritersSixMonths.mdx
+++ b/docs/details/activeWritersSixMonths.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 61
-id: activeWritersSixMonths
+sidebar_position: 60
+id: 61
 title: Require Active Members with Write Access (Activity in 6 Months)
 slug: /details/activeWritersSixMonths
 ---
@@ -8,20 +8,20 @@ slug: /details/activeWritersSixMonths
 # Require Active Members with Write Access (Activity in 6 Months)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 Github Organization Members with Write Permissions Should Have Activity In The Last 6 Months
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R3
 - Mitre: [M1026](https://attack.mitre.org/mitigations/M1026/)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/member/stale_member_found.html)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/adminRepoCreationOnly.mdx
+++ b/docs/details/adminRepoCreationOnly.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 15
-id: adminRepoCreationOnly
+sidebar_position: 14
+id: 15
 title: Allow Only Admins to Create Public Repositories
 slug: /details/adminRepoCreationOnly
 ---
@@ -8,20 +8,21 @@ slug: /details/adminRepoCreationOnly
 # Allow Only Admins to Create Public Repositories
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Only Admins Should Be Able To Create Public Repositories
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [CAPEC-122](https://capec.mitre.org/data/definitions/122.html)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/organization/non_admins_can_create_public_repositories.html)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-organization-settings/restricting-repository-creation-in-your-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/annualDependencyRefresh.mdx
+++ b/docs/details/annualDependencyRefresh.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 53
-id: annualDependencyRefresh
+sidebar_position: 52
+id: 53
 title: Refresh Dependencies with Annual Releases
 slug: /details/annualDependencyRefresh
 ---
@@ -8,20 +8,19 @@ slug: /details/annualDependencyRefresh
 # Refresh Dependencies with Annual Releases
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 A new release to refresh dependencies occurs at least annually
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P14
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [maintained]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.maintained)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/assignCVEForKnownVulns.mdx
+++ b/docs/details/assignCVEForKnownVulns.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 31
-id: assignCVEForKnownVulns
+sidebar_position: 30
+id: 31
 title: Assign CVEs to All Known Security Vulnerabilities
 slug: /details/assignCVEForKnownVulns
 ---
@@ -8,20 +8,19 @@ slug: /details/assignCVEForKnownVulns
 # Assign CVEs to All Known Security Vulnerabilities
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 All Known Security Vulnerabilities are Issued a CVE
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [release_notes_vulns]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.release_notes_vulns)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/automateDependencyManagement.mdx
+++ b/docs/details/automateDependencyManagement.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 50
-id: automateDependencyManagement
+sidebar_position: 49
+id: 50
 title: Automate Monitoring of Outdated Dependencies
 slug: /details/automateDependencyManagement
 ---
@@ -8,20 +8,20 @@ slug: /details/automateDependencyManagement
 # Automate Monitoring of Outdated Dependencies
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Automated Process is Used to Monitor for and Maintain a List of Out of Date Dependencies
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P14
-- Mitre: 
 - Sources: [OWASP SCVS L1 5.7](https://scvs.owasp.org/scvs/v5-component-analysis/)
 - How To: [Socket.Dev](https://socket.dev/)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/automateVulnDetection.mdx
+++ b/docs/details/automateVulnDetection.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 22
-id: automateVulnDetection
+sidebar_position: 21
+id: 22
 title: Automate Dependency Vulnerability Identification
 slug: /details/automateVulnDetection
 ---
@@ -8,20 +8,21 @@ slug: /details/automateVulnDetection
 # Automate Dependency Vulnerability Identification
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 An automated process to identify dependencies with publicly disclosed vulnerabilities
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P6
 - Mitre: [CWE-1395](https://cwe.mitre.org/data/definitions/1395.html)
 - Sources: [OWASP SCVS L1 5.4](https://scvs.owasp.org/scvs/v5-component-analysis/)
 - How To: [Github Docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/blockWorkflowPRApproval.mdx
+++ b/docs/details/blockWorkflowPRApproval.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 35
-id: blockWorkflowPRApproval
+sidebar_position: 34
+id: 35
 title: Prevent Workflows from Creating or Approving PRs
 slug: /details/blockWorkflowPRApproval
 ---
@@ -8,20 +8,21 @@ slug: /details/blockWorkflowPRApproval
 # Prevent Workflows from Creating or Approving PRs
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Workflows are not Allowed To Create or Approve Pull Requests
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P9
 - Mitre: [CWE-250](https://cwe.mitre.org/data/definitions/250.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
 - How To: [Github Docs](https://docs.github.com/en/enterprise-cloud@latest/admin/policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#preventing-github-actions-from-creating-or-approving-pull-requests)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/ciAndCdPipelineAsCode.mdx
+++ b/docs/details/ciAndCdPipelineAsCode.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 48
-id: ciAndCdPipelineAsCode
+sidebar_position: 47
+id: 48
 title: Automate CI/CD Steps in Code-Based Pipelines
 slug: /details/ciAndCdPipelineAsCode
 ---
@@ -8,20 +8,20 @@ slug: /details/ciAndCdPipelineAsCode
 # Automate CI/CD Steps in Code-Based Pipelines
 
 ## Use Case
-
-- Incubating: Deferrable
-- Active: Expected
-- Retiring: N/A
+- Incubating: deferrable
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 CI/CD steps should all be automated through a pipeline defined as code
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P12
-- Mitre: 
 - Sources: [CNCF SSCP 1.0 #158](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#build-and-related-continuous-integrationcontinuous-delivery-steps-should-all-be-automated-through-a-pipeline-defined-as-code)
 - How To: [Github Docs](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/commitSignoffForWeb.mdx
+++ b/docs/details/commitSignoffForWeb.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 63
-id: commitSignoffForWeb
+sidebar_position: 62
+id: 63
 title: Enforce Commit Signoff for Web-Based Commits
 slug: /details/commitSignoffForWeb
 ---
@@ -8,20 +8,20 @@ slug: /details/commitSignoffForWeb
 # Enforce Commit Signoff for Web-Based Commits
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Github Org Requires Commit Signoff for Web-Based Commits
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R4
-- Mitre: 
 - Sources: [CNCF SSCP 1.0 #325](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#require-signed-commits)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-organization-settings/managing-the-commit-signoff-policy-for-your-organization#managing-compulsory-commit-signoffs-for-your-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/commitStatusChecks.mdx
+++ b/docs/details/commitStatusChecks.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 26
-id: commitStatusChecks
+sidebar_position: 25
+id: 26
 title: Require Commit Status Checks to Pass Before Merging
 slug: /details/commitStatusChecks
 ---
@@ -8,20 +8,21 @@ slug: /details/commitStatusChecks
 # Require Commit Status Checks to Pass Before Merging
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 All Required Commit Status Checks must pass before Merging
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P6
 - Mitre: [CWE-358](https://cwe.mitre.org/data/definitions/358.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/consistentBuildProcessDocs.mdx
+++ b/docs/details/consistentBuildProcessDocs.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 45
-id: consistentBuildProcessDocs
+sidebar_position: 44
+id: 45
 title: Document Consistent and Automated Build Processes
 slug: /details/consistentBuildProcessDocs
 ---
@@ -8,20 +8,19 @@ slug: /details/consistentBuildProcessDocs
 # Document Consistent and Automated Build Processes
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Consistent and Automated Build Process is Documented and Used
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P12
 - Mitre: [CWE-1068](https://cwe.mitre.org/data/definitions/1068.html)
-- Sources: 
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/defaultTokenPermissionsReadOnly.mdx
+++ b/docs/details/defaultTokenPermissionsReadOnly.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 34
-id: defaultTokenPermissionsReadOnly
+sidebar_position: 33
+id: 34
 title: Set Default GitHub Workflow Token Permissions to Read Only
 slug: /details/defaultTokenPermissionsReadOnly
 ---
@@ -8,20 +8,19 @@ slug: /details/defaultTokenPermissionsReadOnly
 # Set Default GitHub Workflow Token Permissions to Read Only
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Github Org Default Workflow Token Permissions are Set to Read Only
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P9
 - Mitre: [CWE-250](https://cwe.mitre.org/data/definitions/250.html)
-- Sources: 
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/defineFunctionalRoles.mdx
+++ b/docs/details/defineFunctionalRoles.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 17
-id: defineFunctionalRoles
+sidebar_position: 16
+id: 17
 title: Define Roles Aligned to Functional Responsibilities
 slug: /details/defineFunctionalRoles
 ---
@@ -8,20 +8,21 @@ slug: /details/defineFunctionalRoles
 # Define Roles Aligned to Functional Responsibilities
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Define roles aligned to functional responsibilities
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [CAPEC-122](https://capec.mitre.org/data/definitions/122.html)
 - Sources: [CNCF SSCP v1.0 #188](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#define-roles-aligned-to-functional-responsibilities)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/forkWorkflowApproval.mdx
+++ b/docs/details/forkWorkflowApproval.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 57
-id: forkWorkflowApproval
+sidebar_position: 56
+id: 57
 title: Require Approval for Forked Workflow Changes
 slug: /details/forkWorkflowApproval
 ---
@@ -8,20 +8,20 @@ slug: /details/forkWorkflowApproval
 # Require Approval for Forked Workflow Changes
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Limit changes from forks to workflows by requiring approval for all outside collaborators
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R2
 - Mitre: [CAPEC-180](https://capec.mitre.org/data/definitions/180.html)
 - Sources: [Github Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/githubOrgMFA.mdx
+++ b/docs/details/githubOrgMFA.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 3
-id: githubOrgMFA
+sidebar_position: 72
+id: 3
 title: Enforce MFA in GitHub Organization(s)
 slug: /details/githubOrgMFA
 ---
@@ -8,20 +8,22 @@ slug: /details/githubOrgMFA
 # Enforce MFA in GitHub Organization(s)
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Multi Factor Authentication (MFA) Enforced Across the Github Organization
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: completed
+- Implementation Details: It is computed ([details](https://github.com/secure-dashboards/openjs-foundation-dashboard/issues/43)).
+- C-SCRM: true
 - Priority Group: P1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [OpenSSF SCM Best PracticesOpenSSF Best Practices Badge Gold Level [require_2FA]](https://best.openssf.org/SCM-BestPractices/github/enterprise/enterprise_enforce_two_factor_authentication.html)
 - How To: [Github Docs](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/requiring-two-factor-authentication-in-your-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/githubWebhookSecrets.mdx
+++ b/docs/details/githubWebhookSecrets.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 13
-id: githubWebhookSecrets
+sidebar_position: 12
+id: 13
 title: Secure GitHub Webhooks with Secrets
 slug: /details/githubWebhookSecrets
 ---
@@ -8,20 +8,21 @@ slug: /details/githubWebhookSecrets
 # Secure GitHub Webhooks with Secrets
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Github Webhooks Use Secrets
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P3
 - Mitre: [CWE-306](https://cwe.mitre.org/data/definitions/306)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#webhooks)
 - How To: [Github Docs](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/githubWriteAccessRoles.mdx
+++ b/docs/details/githubWriteAccessRoles.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 18
-id: githubWriteAccessRoles
+sidebar_position: 17
+id: 18
 title: Define Teams/Individuals with Write Access to Repositories
 slug: /details/githubWriteAccessRoles
 ---
@@ -8,20 +8,21 @@ slug: /details/githubWriteAccessRoles
 # Define Teams/Individuals with Write Access to Repositories
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Define Individuals/Teams who Write Access to a Github Repo
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [CAPEC-180](https://capec.mitre.org/data/definitions/180.html)
 - Sources: [CNCF SSCP v1.0 #185](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#define-individualsteams-that-are-responsible-for-code-in-a-repository-and-associated-coding-conventions)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/identifyModifiedDependencies.mdx
+++ b/docs/details/identifyModifiedDependencies.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 52
-id: identifyModifiedDependencies
+sidebar_position: 51
+id: 52
 title: Uniquely Identify Modified Dependencies
 slug: /details/identifyModifiedDependencies
 ---
@@ -8,20 +8,19 @@ slug: /details/identifyModifiedDependencies
 # Uniquely Identify Modified Dependencies
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Modified dependencies are uniquely identified and distinct from origin dependency
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P14
-- Mitre: 
 - Sources: [OWASP SCVS L2 6.5](https://scvs.owasp.org/scvs/v6-pedigree-and-provenance/)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/incidentResponsePlan.mdx
+++ b/docs/details/incidentResponsePlan.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 30
-id: incidentResponsePlan
+sidebar_position: 29
+id: 30
 title: Define Clear Communication and Incident Response Plans
 slug: /details/incidentResponsePlan
 ---
@@ -8,20 +8,19 @@ slug: /details/incidentResponsePlan
 # Define Clear Communication and Incident Response Plans
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Establish a Clear Communication and Incident Response Plan
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/#operations)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/includeCVEInReleaseNotes.mdx
+++ b/docs/details/includeCVEInReleaseNotes.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 32
-id: includeCVEInReleaseNotes
+sidebar_position: 31
+id: 32
 title: Include CVE IDs in Release Notes for Security Fixes
 slug: /details/includeCVEInReleaseNotes
 ---
@@ -8,20 +8,19 @@ slug: /details/includeCVEInReleaseNotes
 # Include CVE IDs in Release Notes for Security Fixes
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Release Notes must Include the CVE ID of Patched Security Vulnerabilities
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [release_notes_vulns]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.release_notes_vulns)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/includePackageLock.mdx
+++ b/docs/details/includePackageLock.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 65
-id: includePackageLock
+sidebar_position: 64
+id: 65
 title: Include package-lock.json in Releases (Freestanding Apps)
 slug: /details/includePackageLock
 ---
@@ -8,20 +8,20 @@ slug: /details/includePackageLock
 # Include package-lock.json in Releases (Freestanding Apps)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 [Freestanding Applications Only] Commit a package-lock.json file with each release
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R5
-- Mitre: 
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sbom)
 - How To: [npm Docs](https://docs.npmjs.com/cli/v10/commands/npm-sbom)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/injectedSecretsAtRuntime.mdx
+++ b/docs/details/injectedSecretsAtRuntime.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 8
-id: injectedSecretsAtRuntime
+sidebar_position: 7
+id: 8
 title: Ensure that the secrets are injected at runtime
 slug: /details/injectedSecretsAtRuntime
 ---
@@ -8,20 +8,21 @@ slug: /details/injectedSecretsAtRuntime
 # Ensure that the secrets are injected at runtime
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Secrets are injected at runtime, such as environment variables or as a file (eg: use Github Secrets)
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P2
 - Mitre: [CWE-538](https://cwe.mitre.org/data/definitions/538.html)
 - Sources: [CNCF CNSWP 2.0 #195](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md#secrets-encryption)
 - How To: [Github Docs](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/limitOrgOwners.mdx
+++ b/docs/details/limitOrgOwners.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 69
-id: limitOrgOwners
+sidebar_position: 68
+id: 69
 title: Limit GitHub Org Owners to Fewer Than Three
 slug: /details/limitOrgOwners
 ---
@@ -8,20 +8,20 @@ slug: /details/limitOrgOwners
 # Limit GitHub Org Owners to Fewer Than Three
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Limit Number of Github Org Owners (ideally Fewer Than Three)
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R7
 - Mitre: [M1026](https://attack.mitre.org/mitigations/M1026/)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/member/organization_has_too_many_admins.html)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/limitRepoAdmins.mdx
+++ b/docs/details/limitRepoAdmins.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 70
-id: limitRepoAdmins
+sidebar_position: 69
+id: 70
 title: Limit GitHub Repo Admins to Fewer Than Three
 slug: /details/limitRepoAdmins
 ---
@@ -8,20 +8,20 @@ slug: /details/limitRepoAdmins
 # Limit GitHub Repo Admins to Fewer Than Three
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Limit Number of Github Repository Admins (ideally Fewer Than Three)
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R7
 - Mitre: [CAPEC-180](https://capec.mitre.org/data/definitions/180.html)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/repository/repository_has_too_many_admins.html)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/limitWorkflowWritePermissions.mdx
+++ b/docs/details/limitWorkflowWritePermissions.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 43
-id: limitWorkflowWritePermissions
+sidebar_position: 42
+id: 43
 title: Limit Workflow Write Permissions to Job-Level
 slug: /details/limitWorkflowWritePermissions
 ---
@@ -8,20 +8,21 @@ slug: /details/limitWorkflowWritePermissions
 # Limit Workflow Write Permissions to Job-Level
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Only Allow Workflows Write Permissions at the Job-Level
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P11
 - Mitre: [CWE-250](https://cwe.mitre.org/data/definitions/250.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
 - How To: [Github Docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/machineReadableDependencies.mdx
+++ b/docs/details/machineReadableDependencies.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 51
-id: machineReadableDependencies
+sidebar_position: 50
+id: 51
 title: Provide Machine-Readable Dependency Lists
 slug: /details/machineReadableDependencies
 ---
@@ -8,20 +8,20 @@ slug: /details/machineReadableDependencies
 # Provide Machine-Readable Dependency Lists
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 [Freestanding Applications Only] A Machine Readable List of all Direct and Transitive Dependencies is Available for the Software
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P14
-- Mitre: 
 - Sources: [OWASP SCVS L1 1.3](https://scvs.owasp.org/scvs/v1-inventory/#verification-requirements)
 - How To: [Github Docs](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-supply-chain-security#what-is-the-dependency-graph)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/noArbitraryCodeInPipeline.mdx
+++ b/docs/details/noArbitraryCodeInPipeline.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 42
-id: noArbitraryCodeInPipeline
+sidebar_position: 41
+id: 42
 title: Restrict Build Pipeline Code Execution to Build Scripts
 slug: /details/noArbitraryCodeInPipeline
 ---
@@ -8,20 +8,20 @@ slug: /details/noArbitraryCodeInPipeline
 # Restrict Build Pipeline Code Execution to Build Scripts
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Build Pipeline Cannot Execute Arbitrary Code from Outside of a Build Script
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P11
 - Mitre: [CWE-94](https://cwe.mitre.org/data/definitions/94.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/noForcePushDefaultBranch.mdx
+++ b/docs/details/noForcePushDefaultBranch.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 36
-id: noForcePushDefaultBranch
+sidebar_position: 35
+id: 36
 title: Disable Force Push on Default Branch
 slug: /details/noForcePushDefaultBranch
 ---
@@ -8,20 +8,20 @@ slug: /details/noForcePushDefaultBranch
 # Disable Force Push on Default Branch
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Prevent Force Push on Default Branch
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P9
-- Mitre: 
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/noSelfHostedRunners.mdx
+++ b/docs/details/noSelfHostedRunners.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 41
-id: noSelfHostedRunners
+sidebar_position: 40
+id: 41
 title: Disable Self-Hosted Runners in GitHub Org
 slug: /details/noSelfHostedRunners
 ---
@@ -8,20 +8,21 @@ slug: /details/noSelfHostedRunners
 # Disable Self-Hosted Runners in GitHub Org
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Disable use of Self-Hosted Runners in Github Org
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P10
 - Mitre: [CAPEC-439](https://capec.mitre.org/data/definitions/439.html)
 - Sources: [Github Action Hardening Docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#limiting-the-use-of-self-hosted-runners)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/noSensitiveInfoInRepositories.mdx
+++ b/docs/details/noSensitiveInfoInRepositories.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 7
-id: noSensitiveInfoInRepositories
+sidebar_position: 6
+id: 7
 title: Check sensitive information
 slug: /details/noSensitiveInfoInRepositories
 ---
@@ -8,20 +8,21 @@ slug: /details/noSensitiveInfoInRepositories
 # Check sensitive information
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 No Secrets and Credentials in Source Code
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P2
 - Mitre: [CWE-540](https://cwe.mitre.org/data/definitions/540.html)
 - Sources: [OpenSSF Best Practices Badge Passing Level [no_leaked_credentials]](https://www.bestpractices.dev/en/criteria#0.no_leaked_credentials)
 - How To: [Github Docs](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/npmOrgMFA.mdx
+++ b/docs/details/npmOrgMFA.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 4
-id: npmOrgMFA
+sidebar_position: 3
+id: 4
 title: Enforce MFA in npm Organization(s)
 slug: /details/npmOrgMFA
 ---
@@ -8,20 +8,21 @@ slug: /details/npmOrgMFA
 # Enforce MFA in npm Organization(s)
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Multi Factor Authentication (MFA) Enforced Across the npm Organization
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [OpenSSF npm Best Practices](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
 - How To: [npm Docs](https://docs.npmjs.com/requiring-two-factor-authentication-in-your-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/npmPublicationMFA.mdx
+++ b/docs/details/npmPublicationMFA.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 12
-id: npmPublicationMFA
+sidebar_position: 11
+id: 12
 title: Publish to npm Using MFA-Enabled Accounts
 slug: /details/npmPublicationMFA
 ---
@@ -8,20 +8,20 @@ slug: /details/npmPublicationMFA
 # Publish to npm Using MFA-Enabled Accounts
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Publish to npm using an MFA-enabled account rather than single factor legacy or granular access tokens
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P3
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [npm Docs](https://docs.npmjs.com/creating-and-viewing-access-tokens)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/orgToolingMFA.mdx
+++ b/docs/details/orgToolingMFA.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 5
-id: orgToolingMFA
+sidebar_position: 4
+id: 5
 title: Enforce MFA in all the tools
 slug: /details/orgToolingMFA
 ---
@@ -8,20 +8,20 @@ slug: /details/orgToolingMFA
 # Enforce MFA in all the tools
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Multi Factor Authentication (MFA) Enforced in All Tools Wherever Techncially Feasible
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [CNCF CNSWP v1.0](https://github.com/cncf/tag-security/blob/main/security-whitepaper/v2/cloud-native-security-whitepaper.md)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/owaspTop10Training.mdx
+++ b/docs/details/owaspTop10Training.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-id: owaspTop10Training
+id: 2
 title: Training on OWASP Top 10 or Equivalent
 slug: /details/owaspTop10Training
 ---
@@ -8,20 +8,20 @@ slug: /details/owaspTop10Training
 # Training on OWASP Top 10 or Equivalent
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 At least One Primary Maintainer has taken TBD Training on OWASP Top 10 or Equivalent
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P0
 - Mitre: [M1013](https://attack.mitre.org/mitigations/M1013/)
 - Sources: [OpenSSF Best Practices Badge Passing Level [know_common_errors]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.know_common_errors)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/patchCriticalVulns30Days.mdx
+++ b/docs/details/patchCriticalVulns30Days.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 20
-id: patchCriticalVulns30Days
+sidebar_position: 19
+id: 20
 title: Patch Actively Exploited Critical Vulnerabilities within 30 Days
 slug: /details/patchCriticalVulns30Days
 ---
@@ -8,20 +8,19 @@ slug: /details/patchCriticalVulns30Days
 # Patch Actively Exploited Critical Vulnerabilities within 30 Days
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Actively Exploited Critical Vulnerabilities Patched within 30 Days
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P5
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [vulnerabilities_critical_fixed]](https://www.bestpractices.dev/en/criteria#0.vulnerabilities_critical_fixed)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/patchExploitableHighVulns14Days.mdx
+++ b/docs/details/patchExploitableHighVulns14Days.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 71
-id: patchExploitableHighVulns14Days
+sidebar_position: 70
+id: 71
 title: Patch Critical/High Vulnerabilities in 14 Days
 slug: /details/patchExploitableHighVulns14Days
 ---
@@ -8,20 +8,19 @@ slug: /details/patchExploitableHighVulns14Days
 # Patch Critical/High Vulnerabilities in 14 Days
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 Actively Exploited Critical and High Vulnerabilities Patched within 14 Days
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: R8
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [vulnerabilities_critical_fixed]](https://www.bestpractices.dev/en/criteria#0.vulnerabilities_critical_fixed)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/patchExploitableNoncCriticalVulns60Days.mdx
+++ b/docs/details/patchExploitableNoncCriticalVulns60Days.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 72
-id: patchExploitableNoncCriticalVulns60Days
+sidebar_position: 71
+id: 72
 title: Patch Non-Critical Vulnerabilities in 60 Days
 slug: /details/patchExploitableNoncCriticalVulns60Days
 ---
@@ -8,20 +8,19 @@ slug: /details/patchExploitableNoncCriticalVulns60Days
 # Patch Non-Critical Vulnerabilities in 60 Days
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 Non-Critical Expoitable Vulnerabilities Patched within 60 Days
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: R8
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Silver Level [vulnerabilities_fixed_60_days]](https://www.bestpractices.dev/en/criteria#0.vulnerabilities_fixed_60_days)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/patchNonCriticalVulns90Days.mdx
+++ b/docs/details/patchNonCriticalVulns90Days.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 21
-id: patchNonCriticalVulns90Days
+sidebar_position: 20
+id: 21
 title: Patch Non-Critical Vulnerabilities within 90 Days
 slug: /details/patchNonCriticalVulns90Days
 ---
@@ -8,20 +8,19 @@ slug: /details/patchNonCriticalVulns90Days
 # Patch Non-Critical Vulnerabilities within 90 Days
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Non-Critical Exploitable Vulnerabilities Patched within 90 Days
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P5
-- Mitre: 
 - Sources: [Google Project Zero Vulnerability Disclosure Policy](https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-policy.html)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/pinActionsToSHA.mdx
+++ b/docs/details/pinActionsToSHA.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 49
-id: pinActionsToSHA
+sidebar_position: 48
+id: 49
 title: Pin Actions with Secrets to Full-Length Commit SHAs
 slug: /details/pinActionsToSHA
 ---
@@ -8,20 +8,20 @@ slug: /details/pinActionsToSHA
 # Pin Actions with Secrets to Full-Length Commit SHAs
 
 ## Use Case
-
-- Incubating: Deferrable
-- Active: Expected
-- Retiring: N/A
+- Incubating: deferrable
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Pin Actions with Access to Secrets to a Full Length Commit SHA
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P13
 - Mitre: [CWE-1357](https://cwe.mitre.org/data/definitions/1357.html)
 - Sources: [Github Docs](https://securitylab.github.com/research/github-actions-building-blocks/)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/preventBranchProtectionBypass.mdx
+++ b/docs/details/preventBranchProtectionBypass.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 16
-id: preventBranchProtectionBypass
+sidebar_position: 15
+id: 16
 title: Prevent Admins from Bypassing Branch Protection
 slug: /details/preventBranchProtectionBypass
 ---
@@ -8,20 +8,21 @@ slug: /details/preventBranchProtectionBypass
 # Prevent Admins from Bypassing Branch Protection
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 [For Projects with Two or more Admins] Do not allow Admins to Bypass Branch Protection Settings
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [CAPEC-122](https://capec.mitre.org/data/definitions/122.html)
 - Sources: [Github Supply Chain Security Best Practices](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#do-not-allow-bypassing-the-above-settings)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/preventDeletionDefaultBranch.mdx
+++ b/docs/details/preventDeletionDefaultBranch.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 37
-id: preventDeletionDefaultBranch
+sidebar_position: 36
+id: 37
 title: Prevent Deletion of Default Branch
 slug: /details/preventDeletionDefaultBranch
 ---
@@ -8,20 +8,21 @@ slug: /details/preventDeletionDefaultBranch
 # Prevent Deletion of Default Branch
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Prevent Default Branch Deletion
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P9
 - Mitre: [CWE-267](https://cwe.mitre.org/data/definitions/267.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/preventLandingSensitiveCommits.mdx
+++ b/docs/details/preventLandingSensitiveCommits.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 10
-id: preventLandingSensitiveCommits
+sidebar_position: 9
+id: 10
 title: Block New Commits with Secrets or Credentials
 slug: /details/preventLandingSensitiveCommits
 ---
@@ -8,20 +8,21 @@ slug: /details/preventLandingSensitiveCommits
 # Block New Commits with Secrets or Credentials
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 New Commits Containing Secrets or Credentials are Blocked from Merging
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P2
 - Mitre: [CWE-358](https://cwe.mitre.org/data/definitions/358.html)
 - Sources: [OpenSSF Best Practices Badge Passing Level [no_leaked_credentials]](https://www.bestpractices.dev/en/criteria#0.no_leaked_credentials)
 - How To: [Github Docs](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/preventScriptInjection.mdx
+++ b/docs/details/preventScriptInjection.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 44
-id: preventScriptInjection
+sidebar_position: 43
+id: 44
 title: Avoid Script Injection from Untrusted Variables
 slug: /details/preventScriptInjection
 ---
@@ -8,20 +8,21 @@ slug: /details/preventScriptInjection
 # Avoid Script Injection from Untrusted Variables
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Avoid Script Injection from Untrusted Context Variables
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P11
 - Mitre: [CWE-454](https://cwe.mitre.org/data/definitions/454.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow)
 - How To: [Github Docs](https://securitylab.github.com/research/github-actions-untrusted-input/)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/regressionTestsForVulns.mdx
+++ b/docs/details/regressionTestsForVulns.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 33
-id: regressionTestsForVulns
+sidebar_position: 32
+id: 33
 title: Create Regression Tests for Bugs and Security Vulnerabilities
 slug: /details/regressionTestsForVulns
 ---
@@ -8,20 +8,19 @@ slug: /details/regressionTestsForVulns
 # Create Regression Tests for Bugs and Security Vulnerabilities
 
 ## Use Case
-
-- Incubating: Deferrable
-- Active: Expected
-- Retiring: N/A
+- Incubating: deferrable
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Regression Tests for => 50% of Bugs and 100% of Security Vulns
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P8
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Silver Level [regression_tests_added50]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.regression_tests_added50)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/requireCodeOwnersReviewForLargeTeams.mdx
+++ b/docs/details/requireCodeOwnersReviewForLargeTeams.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 67
-id: requireCodeOwnersReviewForLargeTeams
+sidebar_position: 66
+id: 67
 title: Require Code Owners Review (Four+ Maintainers)
 slug: /details/requireCodeOwnersReviewForLargeTeams
 ---
@@ -8,20 +8,21 @@ slug: /details/requireCodeOwnersReviewForLargeTeams
 # Require Code Owners Review (Four+ Maintainers)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 [For Projects with Four or more Maintainers] Require Code Owners Review
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R6
 - Mitre: [CAPEC-670](https://capec.mitre.org/data/definitions/670.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review)
 - How To: [Github Docs](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/requirePRApprovalForMainline.mdx
+++ b/docs/details/requirePRApprovalForMainline.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 68
-id: requirePRApprovalForMainline
+sidebar_position: 67
+id: 68
 title: Require Approved PRs for Mainline Commits (Two+ Maintainers)
 slug: /details/requirePRApprovalForMainline
 ---
@@ -8,20 +8,21 @@ slug: /details/requirePRApprovalForMainline
 # Require Approved PRs for Mainline Commits (Two+ Maintainers)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 [For Projects with Two or more Maintainers] Require Approved PRs for all commits to mainline branches
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R6
 - Mitre: [CAPEC-670](https://capec.mitre.org/data/definitions/670.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/requireSignedCommits.mdx
+++ b/docs/details/requireSignedCommits.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 64
-id: requireSignedCommits
+sidebar_position: 63
+id: 64
 title: Require Signed Commits
 slug: /details/requireSignedCommits
 ---
@@ -8,20 +8,20 @@ slug: /details/requireSignedCommits
 # Require Signed Commits
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Require Signed Commits
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R4
-- Mitre: 
 - Sources: [CNCF SSCP 1.0 #325](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#require-signed-commits)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/requireTwoPartyReview.mdx
+++ b/docs/details/requireTwoPartyReview.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 66
-id: requireTwoPartyReview
+sidebar_position: 65
+id: 66
 title: Require Two-Party Review (Two+ Maintainers)
 slug: /details/requireTwoPartyReview
 ---
@@ -8,20 +8,21 @@ slug: /details/requireTwoPartyReview
 # Require Two-Party Review (Two+ Maintainers)
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: N/A
+- Incubating: recommended
+- Active: recommended
+- Retiring: n/a
 
 ## Description
 
 [For Projects with Two or more Maintainers] Require Two Party Review
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R6
 - Mitre: [CAPEC-670](https://capec.mitre.org/data/definitions/670.html)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/resolveLinterWarnings.mdx
+++ b/docs/details/resolveLinterWarnings.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 24
-id: resolveLinterWarnings
+sidebar_position: 23
+id: 24
 title: Address Compiler/Linter Warnings Before Merging
 slug: /details/resolveLinterWarnings
 ---
@@ -8,20 +8,21 @@ slug: /details/resolveLinterWarnings
 # Address Compiler/Linter Warnings Before Merging
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Compilers/Linter Warnings Addressed in order to Merge
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P6
 - Mitre: [CWE-1127](https://cwe.mitre.org/data/definitions/1127.html)
 - Sources: [OpenSSF Best Practices Badge Silver Level [warnings_strict]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.warnings_strict)
 - How To: [ESLint Docs](https://eslint.org/docs/latest/use/getting-started#installation-and-usage)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/restrictOrgSecrets.mdx
+++ b/docs/details/restrictOrgSecrets.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 39
-id: restrictOrgSecrets
+sidebar_position: 38
+id: 39
 title: Restrict GitHub Org Secrets to Specific Repositories
 slug: /details/restrictOrgSecrets
 ---
@@ -8,20 +8,21 @@ slug: /details/restrictOrgSecrets
 # Restrict GitHub Org Secrets to Specific Repositories
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 GitHub Organization Secrets are Restricted to Selected Repositories
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P10
 - Mitre: [CWE-250](https://cwe.mitre.org/data/definitions/250.html)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/actions/all_repositories_can_run_github_actions.html)
 - How To: [Github Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/restrictedOrgPermissions.mdx
+++ b/docs/details/restrictedOrgPermissions.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 14
-id: restrictedOrgPermissions
+sidebar_position: 13
+id: 14
 title: Restrict Default GitHub Org Member Permissions
 slug: /details/restrictedOrgPermissions
 ---
@@ -8,20 +8,21 @@ slug: /details/restrictedOrgPermissions
 # Restrict Default GitHub Org Member Permissions
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Default Github Org Member Permissions Should Be Restricted
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [CAPEC-180](https://capec.mitre.org/data/definitions/180.html)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/organization/default_repository_permission_is_not_none.html)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/runnerSecurityScanner.mdx
+++ b/docs/details/runnerSecurityScanner.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 59
-id: runnerSecurityScanner
+sidebar_position: 58
+id: 59
 title: Use GitHub Runner Security Scanners
 slug: /details/runnerSecurityScanner
 ---
@@ -8,20 +8,21 @@ slug: /details/runnerSecurityScanner
 # Use GitHub Runner Security Scanners
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Use a Github Runner Security Scanner
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R2
 - Mitre: [M1047](https://attack.mitre.org/mitigations/M1047/)
 - Sources: [Github Action Hardening Docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners)
 - How To: [Step Security harden-runner](https://github.com/step-security/harden-runner)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/scanCommitsForSensitiveInfo.mdx
+++ b/docs/details/scanCommitsForSensitiveInfo.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 9
-id: scanCommitsForSensitiveInfo
+sidebar_position: 8
+id: 9
 title: Ensure that all the commits are scanned
 slug: /details/scanCommitsForSensitiveInfo
 ---
@@ -8,20 +8,21 @@ slug: /details/scanCommitsForSensitiveInfo
 # Ensure that all the commits are scanned
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 All Commits are Scanned for Secrets and Credentials 
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P2
 - Mitre: [CWE-540](https://cwe.mitre.org/data/definitions/540.html)
 - Sources: [CNCF SSCP v1.0 #184](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/sscsp.md#user-content-fnref-21-4e56305414bd02da4843ec1d7d856144)
 - How To: [Github Docs](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/securityMdMeetsOpenJSCVD.mdx
+++ b/docs/details/securityMdMeetsOpenJSCVD.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 27
-id: securityMdMeetsOpenJSCVD
+sidebar_position: 26
+id: 27
 title: Ensure Security.md Meets OpenJS CVD Guidelines
 slug: /details/securityMdMeetsOpenJSCVD
 ---
@@ -8,20 +8,19 @@ slug: /details/securityMdMeetsOpenJSCVD
 # Ensure Security.md Meets OpenJS CVD Guidelines
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Security.md Meets OpenJS CVD Guidelines 
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy)
-- How To: OpenJS CVD Guidance
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/softwareArchitectureDocs.mdx
+++ b/docs/details/softwareArchitectureDocs.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 47
-id: softwareArchitectureDocs
+sidebar_position: 46
+id: 47
 title: Document Software Architecture
 slug: /details/softwareArchitectureDocs
 ---
@@ -8,20 +8,20 @@ slug: /details/softwareArchitectureDocs
 # Document Software Architecture
 
 ## Use Case
-
-- Incubating: Deferrable
-- Active: Expected
-- Retiring: N/A
+- Incubating: deferrable
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 [For Projects with Two or more Maintainers] Document Software Architecture
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P12
 - Mitre: [CWE-1053](https://cwe.mitre.org/data/definitions/1053.html)
 - Sources: [OpenSSF Best Practices Badge Silver Level [documentation_architecture]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.documentation_architecture)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/softwareDesignTraining.mdx
+++ b/docs/details/softwareDesignTraining.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-id: softwareDesignTraining
+id: 1
 title: Training on Secure Software Design
 slug: /details/softwareDesignTraining
 ---
@@ -8,20 +8,20 @@ slug: /details/softwareDesignTraining
 # Training on Secure Software Design
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 At least One Primary Maintainer has taken TBD Training on Secure Software Design
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P0
 - Mitre: [M1013](https://attack.mitre.org/mitigations/M1013/)
 - Sources: [OpenSSF Best Practices Badge Passing Level [know_secure_design]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.know_secure_design)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/staticAppSecTesting.mdx
+++ b/docs/details/staticAppSecTesting.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 25
-id: staticAppSecTesting
+sidebar_position: 24
+id: 25
 title: Use Static Application Security Testing for All Commits
 slug: /details/staticAppSecTesting
 ---
@@ -8,20 +8,21 @@ slug: /details/staticAppSecTesting
 # Use Static Application Security Testing for All Commits
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 All Commits are Scanned by a Static Application Security Testing Tool
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P6
 - Mitre: [CWE-1076](https://cwe.mitre.org/data/definitions/1076.html)
 - Sources: [OWASP SCVS L1 6.6OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast)
 - How To: [CodeQL Docs](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/staticCodeAnalysis.mdx
+++ b/docs/details/staticCodeAnalysis.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 23
-id: staticCodeAnalysis
+sidebar_position: 22
+id: 23
 title: Use Automated Static Code Analysis Tools
 slug: /details/staticCodeAnalysis
 ---
@@ -8,20 +8,21 @@ slug: /details/staticCodeAnalysis
 # Use Automated Static Code Analysis Tools
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Use an Automated Static Code Analysis Tool (eg: ESLInt)
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P6
 - Mitre: [CWE-1076](https://cwe.mitre.org/data/definitions/1076.html)
 - Sources: [OWASP SCVS L1 5.1](https://scvs.owasp.org/scvs/v5-component-analysis/)
 - How To: [ESLint Docs](https://eslint.org/docs/latest/use/getting-started#installation-and-usage)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/twoOrMoreOwnersForAccess.mdx
+++ b/docs/details/twoOrMoreOwnersForAccess.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 19
-id: twoOrMoreOwnersForAccess
+sidebar_position: 18
+id: 19
 title: Configure Two or more Owners for Access Continuity
 slug: /details/twoOrMoreOwnersForAccess
 ---
@@ -8,20 +8,21 @@ slug: /details/twoOrMoreOwnersForAccess
 # Configure Two or more Owners for Access Continuity
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 [For Projects with Two or more Owners] Have at least Two Owners Configured for Access Continuity
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P4
 - Mitre: [M1026](https://attack.mitre.org/mitigations/M1026/)
 - Sources: [OpenSSF Best Practices Badge Silver Level [access_continuity]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.access_continuity)
 - How To: [Github Docs](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/maintaining-ownership-continuity-for-your-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/upToDateDefaultBranchBeforeMerge.mdx
+++ b/docs/details/upToDateDefaultBranchBeforeMerge.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 38
-id: upToDateDefaultBranchBeforeMerge
+sidebar_position: 37
+id: 38
 title: Require Default Branch Updates Before Merging
 slug: /details/upToDateDefaultBranchBeforeMerge
 ---
@@ -8,20 +8,20 @@ slug: /details/upToDateDefaultBranchBeforeMerge
 # Require Default Branch Updates Before Merging
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Default Branch must be Up to Date before Merging
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P9
-- Mitre: 
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
 - How To: [Github Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/upgradePathDocs.mdx
+++ b/docs/details/upgradePathDocs.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 46
-id: upgradePathDocs
+sidebar_position: 45
+id: 46
 title: Support Older Versions or Provide Upgrade Paths
 slug: /details/upgradePathDocs
 ---
@@ -8,20 +8,19 @@ slug: /details/upgradePathDocs
 # Support Older Versions or Provide Upgrade Paths
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 Commonly Used Older Versions Supported or Upgrade Path Provided/Documented
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P12
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Silver Level [maintenance_or_update]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#1.maintenance_or_update)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/useCVDToolForVulns.mdx
+++ b/docs/details/useCVDToolForVulns.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 28
-id: useCVDToolForVulns
+sidebar_position: 27
+id: 28
 title: Use CVD Tools to Manage Vulnerability Reports
 slug: /details/useCVDToolForVulns
 ---
@@ -8,20 +8,20 @@ slug: /details/useCVDToolForVulns
 # Use CVD Tools to Manage Vulnerability Reports
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: Expected
+- Incubating: expected
+- Active: expected
+- Retiring: expected
 
 ## Description
 
 Project Leverages a CVD Tool to Privately Receive/Manage External Vulnerability Reports (eg: H1/GH PVR)
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [vulnerability_report_private]](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.vulnerability_report_private)
 - How To: [Github Docs](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-an-organization)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/useHwKeyGithubAccess.mdx
+++ b/docs/details/useHwKeyGithubAccess.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 54
-id: useHwKeyGithubAccess
+sidebar_position: 53
+id: 54
 title: Use AAL2/3 Passkeys for GitHub Access
 slug: /details/useHwKeyGithubAccess
 ---
@@ -8,20 +8,21 @@ slug: /details/useHwKeyGithubAccess
 # Use AAL2/3 Passkeys for GitHub Access
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
-[object Object]
+{"url":"http://github.com/","description":"Github.com"}
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [OpenSSF Great MFA Project Security Rationale](https://github.com/ossf/great-mfa-project/blob/main/security-rationale.md)
 - How To: [Github Docs](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-passkey)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/useHwKeyGithubNonInteractive.mdx
+++ b/docs/details/useHwKeyGithubNonInteractive.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 55
-id: useHwKeyGithubNonInteractive
+sidebar_position: 54
+id: 55
 title: Use AAL2/3 Passkeys for Non-Interactive GitHub Access
 slug: /details/useHwKeyGithubNonInteractive
 ---
@@ -8,20 +8,21 @@ slug: /details/useHwKeyGithubNonInteractive
 # Use AAL2/3 Passkeys for Non-Interactive GitHub Access
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Non-Interactive Github: Use a passkey (AAL2) or hardware key (AAL3) that activates using a password or biometrics
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [OpenSSF Great MFA Project Security Rationale](https://github.com/ossf/great-mfa-project/blob/main/security-rationale.md)
 - How To: [Github Docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key-for-a-hardware-security-key)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/useHwKeyOtherContexts.mdx
+++ b/docs/details/useHwKeyOtherContexts.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 56
-id: useHwKeyOtherContexts
+sidebar_position: 55
+id: 56
 title: Use AAL2/3 Passkeys in All Other Contexts
 slug: /details/useHwKeyOtherContexts
 ---
@@ -8,20 +8,20 @@ slug: /details/useHwKeyOtherContexts
 # Use AAL2/3 Passkeys in All Other Contexts
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 All Other Contexts: Use a passkey (AAL2) or hardware key (AAL3) that activates using a password or biometrics
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R1
 - Mitre: [CWE-308](https://cwe.mitre.org/data/definitions/308.html)
 - Sources: [OpenSSF Great MFA Project Security Rationale](https://github.com/ossf/great-mfa-project/blob/main/security-rationale.md)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/verifiedActionsOnly.mdx
+++ b/docs/details/verifiedActionsOnly.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 40
-id: verifiedActionsOnly
+sidebar_position: 39
+id: 40
 title: Limit GitHub Actions to Verified or Trusted Actions
 slug: /details/verifiedActionsOnly
 ---
@@ -8,20 +8,21 @@ slug: /details/verifiedActionsOnly
 # Limit GitHub Actions to Verified or Trusted Actions
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 GitHub Actions Should Be Limited To Verified or Explicitly Trusted Actions
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: P10
 - Mitre: [CWE-1357](https://cwe.mitre.org/data/definitions/1357.html)
 - Sources: [OpenSSF SCM Best Practices](https://best.openssf.org/SCM-BestPractices/github/actions/all_github_actions_are_allowed.html)
 - How To: [Github Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/vulnResponse14Days.mdx
+++ b/docs/details/vulnResponse14Days.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 29
-id: vulnResponse14Days
+sidebar_position: 28
+id: 29
 title: Respond to External Vulnerability Reports in Under 14 Days
 slug: /details/vulnResponse14Days
 ---
@@ -8,20 +8,19 @@ slug: /details/vulnResponse14Days
 # Respond to External Vulnerability Reports in Under 14 Days
 
 ## Use Case
-
-- Incubating: Expected
-- Active: Expected
-- Retiring: N/A
+- Incubating: expected
+- Active: expected
+- Retiring: n/a
 
 ## Description
 
 All External Vulnerability Reports Responded to <14 Days
 
 ## Details
-
-- C-SCRM: 
+- Implementation Status: pending
+- C-SCRM: false
 - Priority Group: P7
-- Mitre: 
 - Sources: [OpenSSF Best Practices Badge Passing Level [vulnerability_report_response]](https://www.bestpractices.dev/en/criteria#0.vulnerability_report_response)
-- How To: 
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/docs/details/workflowSecurityScanner.mdx
+++ b/docs/details/workflowSecurityScanner.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 58
-id: workflowSecurityScanner
+sidebar_position: 57
+id: 58
 title: Use Workflow Security Scanners
 slug: /details/workflowSecurityScanner
 ---
@@ -8,20 +8,21 @@ slug: /details/workflowSecurityScanner
 # Use Workflow Security Scanners
 
 ## Use Case
-
-- Incubating: Recommended
-- Active: Recommended
-- Retiring: Recommended
+- Incubating: recommended
+- Active: recommended
+- Retiring: recommended
 
 ## Description
 
 Use a Workflow Security Scanner
 
 ## Details
-
-- C-SCRM: Y
+- Implementation Status: pending
+- C-SCRM: true
 - Priority Group: R2
 - Mitre: [M1047](https://attack.mitre.org/mitigations/M1047/)
 - Sources: [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
 - How To: [Step Security secure-repo](https://github.com/step-security/secure-repo)
+- Created at 2024-12-07T23:06:38.197Z
+- Updated at 2024-12-07T23:06:38.197Z
 

--- a/scripts/populate-details.js
+++ b/scripts/populate-details.js
@@ -1,45 +1,79 @@
 const { writeFileSync } = require('fs')
 const path = require('path')
 
-const standards = require('../data/standards.json')
+const checks = require('../data/checks.json')
 
-const addContent = (content) => {
-  if (typeof content === 'string') {
-    return content
+const addImplementationDetails = (check) => {
+  if (!check.implementation_type) {
+    return ''
+  }
+  let content = `- Implementation Details: It is ${check.implementation_type}`
+  if (check.implementation_details_reference) {
+    content += ` ([details](${check.implementation_details_reference})).`
+  }
+  return content
+}
+
+const addContent = (title, description, url) => {
+  if (!description && !url) {
+    return ''
   }
 
-  return `[${content.description}](${content.url})`
+  if (url) {
+    return `- ${title}: [${description}](${url})`
+  }
+
+  return `- ${title}: ${description}`
 }
+
+const renderDetails = (check) => {
+  const implementationDetails = addImplementationDetails(check)
+  const mitreDetails = addContent('Mitre', check.mitre_description, check.mitre_url)
+  const sourcesDetails = addContent('Sources', check.sources_description, check.sources_url)
+  const howToDetails = addContent('How To', check.how_to_description, check.how_to_url)
+  let content = '## Details\n'
+  content += `- Implementation Status: ${check.implementation_status}\n`
+  if (implementationDetails) {
+    content += `${implementationDetails}\n`
+  }
+  content += `- C-SCRM: ${check.is_c_scrm}\n`
+  content += `- Priority Group: ${check.priority_group}\n`
+  if (mitreDetails) {
+    content += `${mitreDetails}\n`
+  }
+  if (sourcesDetails) {
+    content += `${sourcesDetails}\n`
+  }
+  if (howToDetails) {
+    content += `${howToDetails}\n`
+  }
+  content += `- Created at ${check.created_at}\n`
+  content += `- Updated at ${check.updated_at}\n`
+  return content
+}
+
 // Prepare the markdown files
-standards.forEach((item, index) => {
+checks.forEach((check, index) => {
   const fileContent = `---
 sidebar_position: ${index + 1}
-id: ${item.slug}
-title: ${item.title}
-slug: /details/${item.slug}
+id: ${check.id}
+title: ${check.title}
+slug: /details/${check.code_name}
 ---
 
-# ${item.title}
+# ${check.title}
 
 ## Use Case
-
-- Incubating: ${item.incubating}
-- Active: ${item.active}
-- Retiring: ${item.retiring}
+- Incubating: ${check.level_incubating_status}
+- Active: ${check.level_active_status}
+- Retiring: ${check.level_retiring_status}
 
 ## Description
 
-${item.description}
+${check.description}
 
-## Details
-
-- C-SCRM: ${item['c-scrm']}
-- Priority Group: ${item['priority group']}
-- Mitre: ${addContent(item.mitre)}
-- Sources: ${addContent(item.sources)}
-- How To: ${addContent(item['how to'])}
-
+${renderDetails(check)}
 `
-  const detination = path.join(process.cwd(), `docs/details/${item.slug}.mdx`)
+  const detination = path.join(process.cwd(), `docs/details/${check.code_name}.mdx`)
   writeFileSync(detination, fileContent)
 })


### PR DESCRIPTION
### Main Changes
- The population scripts `populate-details` (bec24b1) and `populate-implementations` (5703528) are now using the new data source (dashboard database dump)
- The detatils files now include more information, also some minor bugs were solved (5550e40)

### Context

Related to #10 and #14

### Changelog
- bec24b1 feat: migrate populate-details script to the new data source by @UlisesGascon
- 5550e40 chore: update details by @UlisesGascon
- 5703528 feat: migrate populate-implementations script to the new data source by @UlisesGascon